### PR TITLE
Fix getCategories test usage

### DIFF
--- a/src/Trait/CategoryApiTrait.php
+++ b/src/Trait/CategoryApiTrait.php
@@ -30,7 +30,7 @@ trait CategoryApiTrait
             throw new InvalidArgumentException('Limit cannot be greater than 250');
         }
 
-        return $this->get(self::ENDPOINT_CATEGORIES, Categories::class);
+        return $this->get(self::ENDPOINT_CATEGORIES, Categories::class, ['offset' => $offset, 'limit' => $limit]);
     }
 
     public function createCategory(Category $category): void

--- a/tests/CategoryApiTraitTest.php
+++ b/tests/CategoryApiTraitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ */
+
+declare(strict_types=1);
+
+namespace Stovendo\Omnisend\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Stovendo\Omnisend\Exception\InvalidArgumentException;
+use Stovendo\Omnisend\Model\Categories;
+use Stovendo\Omnisend\Trait\CategoryApiTrait;
+
+#[CoversClass(CategoryApiTrait::class)]
+class CategoryApiTraitTest extends TestCase
+{
+    public function test_get_categories_passes_query_parameters(): void
+    {
+        $client = new class() {
+            use CategoryApiTrait;
+
+            public array $args = [];
+            private const ENDPOINT_CATEGORIES = '/categories';
+
+            public function get(string $endpoint, string $expectedType, array $query = []): object
+            {
+                $this->args = [$endpoint, $expectedType, $query];
+                return new Categories([]);
+            }
+        };
+
+        $client->getCategories(5, 10);
+
+        [$endpoint, $type, $query] = $client->args;
+        $this->assertSame('/categories', $endpoint);
+        $this->assertSame(Categories::class, $type);
+        $this->assertSame(['offset' => 5, 'limit' => 10], $query);
+    }
+
+    public function test_get_categories_with_limit_over_250_throws_exception(): void
+    {
+        $client = new class() {
+            use CategoryApiTrait;
+            private const ENDPOINT_CATEGORIES = '/categories';
+
+            public function get(string $endpoint, string $expectedType, array $query = []): object
+            {
+                return new Categories([]);
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $client->getCategories(0, 251);
+    }
+}


### PR DESCRIPTION
## Summary
- add `#[CoversClass]` annotation to CategoryApiTraitTest
- instantiate `Categories` with an empty array
- forward offset and limit in getCategories on a single line

## Testing
- `make test` *(fails: `php: command not found`)*