### PR TITLE
Fix getCategories offset & limit

### DIFF
--- a/src/Trait/CategoryApiTrait.php
+++ b/src/Trait/CategoryApiTrait.php
@@ -30,7 +30,11 @@ trait CategoryApiTrait
             throw new InvalidArgumentException('Limit cannot be greater than 250');
         }
 
-        return $this->get(self::ENDPOINT_CATEGORIES, Categories::class);
+        return $this->get(
+            self::ENDPOINT_CATEGORIES,
+            Categories::class,
+            ['offset' => $offset, 'limit' => $limit]
+        );
     }
 
     public function createCategory(Category $category): void

--- a/tests/CategoryApiQueryTest.php
+++ b/tests/CategoryApiQueryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ */
+
+declare(strict_types=1);
+
+namespace Stovendo\Omnisend\Tests;
+
+use Http\Discovery\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Stovendo\Omnisend\OmnisendApiClient;
+use Stovendo\Omnisend\Serializer;
+use Stovendo\Omnisend\Trait\CategoryApiTrait;
+
+class RecordingHttpClient implements ClientInterface
+{
+    public ?RequestInterface $lastRequest = null;
+
+    public function __construct(private ResponseInterface $response)
+    {
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->lastRequest = $request;
+
+        return $this->response;
+    }
+}
+
+#[CoversClass(CategoryApiTrait::class)]
+class CategoryApiQueryTest extends TestCase
+{
+    public function test_get_categories_uses_offset_and_limit_query(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response = $psr17Factory->createResponse(200);
+        $response->getBody()->write('{"categories": []}');
+        $response->getBody()->rewind();
+
+        $client = new RecordingHttpClient($response);
+
+        $api = new OmnisendApiClient(
+            apikey: 'test',
+            httpClient: $client,
+            psrFactory: $psr17Factory,
+            serializer: new Serializer(),
+            endpoint: 'https://api.example.com'
+        );
+
+        $api->getCategories(5, 10);
+
+        $lastRequest = $client->lastRequest;
+        $this->assertInstanceOf(RequestInterface::class, $lastRequest);
+        $this->assertSame('offset=5&limit=10', $lastRequest->getUri()->getQuery());
+    }
+}


### PR DESCRIPTION
## Summary
- pass offset and limit query params to `getCategories`
- add test to ensure query parameters are used

## Testing
- `php ./vendor/bin/php-cs-fixer fix --dry-run --allow-risky yes`
- `php ./vendor/bin/phpstan`
- `php ./vendor/bin/phpunit --testdox`
