### PR TITLE
Add orders API support

### DIFF
--- a/src/Model/Orders.php
+++ b/src/Model/Orders.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ */
+
+declare(strict_types=1);
+
+namespace Stovendo\Omnisend\Model;
+
+use ArrayAccess;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use RuntimeException;
+use Traversable;
+
+/**
+ * @implements IteratorAggregate<int, Order>
+ * @implements ArrayAccess<int, Order>
+ */
+class Orders implements IteratorAggregate, Countable, ArrayAccess
+{
+    /**
+     * @param array<Order> $orders
+     */
+    public function __construct(
+        public array $orders,
+    ) {
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->orders);
+    }
+
+    public function count(): int
+    {
+        return count($this->orders);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->orders[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): Order
+    {
+        return $this->orders[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new RuntimeException('Setting values is not allowed');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new RuntimeException('Unsetting values is not allowed');
+    }
+}

--- a/src/OmnisendApi.php
+++ b/src/OmnisendApi.php
@@ -20,6 +20,7 @@ use Stovendo\Omnisend\Model\Contact;
 use Stovendo\Omnisend\Model\CustomEvent;
 use Stovendo\Omnisend\Model\NewContact;
 use Stovendo\Omnisend\Model\Order;
+use Stovendo\Omnisend\Model\Orders;
 use Stovendo\Omnisend\Model\Product;
 use Stovendo\Omnisend\Model\Products;
 
@@ -74,6 +75,10 @@ interface OmnisendApi
     public function replaceOrder(Order $order): void;
 
     public function upsertOrder(Order $order): void;
+
+    public function deleteOrder(string $orderId): void;
+
+    public function getOrders(int $offset = 0, int $limit = 250): Orders;
 
     public function getProduct(string $productId): ?Product;
 

--- a/src/Trait/OrderApiTrait.php
+++ b/src/Trait/OrderApiTrait.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 
 namespace Stovendo\Omnisend\Trait;
 
+use Stovendo\Omnisend\Exception\InvalidArgumentException;
 use Stovendo\Omnisend\Exception\OrderNotFoundException;
 use Stovendo\Omnisend\Model\Order;
+use Stovendo\Omnisend\Model\Orders;
 
 trait OrderApiTrait
 {
@@ -34,6 +36,24 @@ trait OrderApiTrait
             return $this->get('/orders/'.$orderId, Order::class);
         } catch (OrderNotFoundException) {
             return null;
+        }
+    }
+
+    public function getOrders(int $offset = 0, int $limit = 250): Orders
+    {
+        if ($limit > 250) {
+            throw new InvalidArgumentException('Limit cannot be greater than 250');
+        }
+
+        return $this->get('/orders', Orders::class, ['offset' => $offset, 'limit' => $limit]);
+    }
+
+    public function deleteOrder(string $orderId): void
+    {
+        try {
+            $this->delete('/orders', $orderId);
+        } catch (OrderNotFoundException) {
+            // if it's not there, ignore it
         }
     }
 }

--- a/tests/OmnisendApiClientTest.php
+++ b/tests/OmnisendApiClientTest.php
@@ -390,6 +390,25 @@ class OmnisendApiClientTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function test_get_orders(): void
+    {
+        $orders = $this->createClient()->getOrders();
+        $this->assertNotEmpty($orders);
+        $this->assertContainsOnlyInstancesOf(Order::class, $orders);
+    }
+
+    public function test_delete_order(): void
+    {
+        $this->createClient()->deleteOrder('order-1');
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_delete_not_existing_order_does_not_throw_exception(): void
+    {
+        $this->createClient()->deleteOrder('order-404');
+        $this->addToAssertionCount(1);
+    }
+
     private function createClient(): OmnisendApi
     {
         $apikey = $_ENV['OMNISEND_TEST_APIKEY'] ?? 'none';

--- a/tests/recordings/test_delete_not_existing_order_does_not_throw_exception.txt
+++ b/tests/recordings/test_delete_not_existing_order_does_not_throw_exception.txt
@@ -1,0 +1,8 @@
+HTTP/1.1 404 Not Found
+date: Wed, 08 May 2024 19:02:34 GMT
+content-type: application/json
+via: 1.1 google
+server: cloudflare
+content-encoding: gzip
+
+{"error":"Order with 'order-404' orderID not found"}

--- a/tests/recordings/test_delete_order.txt
+++ b/tests/recordings/test_delete_order.txt
@@ -1,0 +1,5 @@
+HTTP/1.1 204 No Content
+date: Wed, 08 May 2024 19:02:33 GMT
+via: 1.1 google
+server: cloudflare
+

--- a/tests/recordings/test_get_orders.txt
+++ b/tests/recordings/test_get_orders.txt
@@ -1,0 +1,7 @@
+HTTP/1.1 200 OK
+date: Tue, 21 May 2024 11:28:12 GMT
+content-type: application/json; charset=utf-8
+via: 1.1 google
+server: cloudflare
+
+{"orders":[{"orderID":"order-1","email":"john.doe@example.com","orderNumber":10001,"currency":"EUR","orderSum":3120,"createdAt":"2021-01-01T00:00:00Z","paymentStatus":"paid","fulfillmentStatus":"fulfilled","orderItems":[{"productID":"product-1","sku":"apple-1","variantID":"product-1-1","variantTitle":"Apple Juice in a bottle","title":"Apple Juice in a bottle","price":1560,"quantity":1,"imageUrl":null,"productUrl":null,"categoryIDs":[]},{"productID":"product-2","sku":"banana-1","variantID":"product-2-1","variantTitle":"Banana Juice in a bottle","title":"Banana Juice in a bottle","price":1560,"quantity":1,"imageUrl":null,"productUrl":null,"categoryIDs":[]}]}]}


### PR DESCRIPTION
## Summary
- add `Orders` collection model
- implement `getOrders` and `deleteOrder` methods
- expose new methods via `OmnisendApi` interface
- cover new functionality with unit tests and fixtures

## Testing
- `php ./vendor/bin/php-cs-fixer fix --dry-run --allow-risky yes`
- `php ./vendor/bin/phpstan`
- `php ./vendor/bin/phpunit --testdox`
